### PR TITLE
fix warning i2c_config declaration

### DIFF
--- a/src/LIS3DHTR.cpp
+++ b/src/LIS3DHTR.cpp
@@ -50,9 +50,11 @@ void LIS3DHTR::begin(uint8_t address)
         .scl_io_num = I2C_MASTER_SCL_IO,
         .sda_pullup_en = GPIO_PULLUP_ENABLE,
         .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master = {
+            .clk_speed = I2C_MASTER_FREQ_HZ
+        },
+        .clk_flags = I2C_SCLK_SRC_FLAG_FOR_NOMAL
     };
-
-    conf.master.clk_speed = I2C_MASTER_FREQ_HZ;
 
     i2c_param_config(i2c_master_port, &conf);
 


### PR DESCRIPTION
It is proposed to add clk_speed to the i2c_conf declaration block to avoid build warning, clk_flags is set to I2C_SCLK_SRC_FLAG_FOR_NOMAL (0) based on esp-idf doc https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/i2c.html